### PR TITLE
Add shortcut setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Generates links like [✅ My todo](https://www.notion.so/licarth/My-todo-a80d4d5
 ## Install
 
 1. Install [Tampermonkey](https://www.tampermonkey.net/) (browser extension for Chrome, Safari, Edge, Firefox, Opera).
-1. Go to the extension’s `Dashboard` > `Utilities` > `Import from URL`. 
+1. Go to the extension’s `Dashboard` > `Utilities` > `Import from URL`.
 Paste this link `https://raw.githubusercontent.com/licarth/paste-notion-urls/main/tampermonkey-script.js` and click Install.
 1. Go (or refresh) to a Notion page, click on top-right “Copy Formatted URL” on the top right.
 1. You can paste your link in Slack with `cmd/ctrl + V`
 1. You can paste your links in Markdown format (for GitHub issues) with `maj + cmd/ctrl + V`
+1. Set your own shortcut clicking on Tampermonkey icon, and on `Set copy shortcut`.
+<img width="860" alt="Menu Screenshot" src="https://user-images.githubusercontent.com/47712216/236692623-817535c2-121f-4d50-94df-dd84ee124a8a.png">
 
 ## Contribute
 Contributions are welcome. Issues are in [this GitHub project](https://github.com/licarth/paste-notion-urls/issues).

--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -20,6 +20,22 @@ const INITIAL_BUTTON_TEXT = "link";
 
 const IS_DARK_MODE = document.body.classList.contains("dark");
 
+const DEFAULT_SHORTCUT = {
+  shortcutKey: {
+    code: 'KeyL',
+    key: 'l'
+  },
+  shortcutModifiers: {
+    shift: { symbol: "⇧", key: "shiftKey", pressed: true },
+    control: { symbol: "⌃", key: "ctrlKey", pressed: false },
+    option: { symbol: "⌥", key: "altKey", pressed: true },
+    command: { symbol: "⌘/⊞", key: "metaKey", pressed: true },
+  }
+}
+
+const STORED_SHORTCUT = JSON.parse(localStorage.getItem('shortcut'));
+const currentShortcut = STORED_SHORTCUT ? STORED_SHORTCUT : DEFAULT_SHORTCUT;
+
 const textColor = IS_DARK_MODE
   ? "rgba(255, 255, 255, 0.81)"
   : "rgb(55, 53, 47)";
@@ -139,9 +155,16 @@ align-items: center;
       .addEventListener("click", () => onButtonClickMain(el), false);
   }
 
+  function isCurrentShortcutPressed(event) {
+    return event.code === currentShortcut.shortcutKey.code
+      && Object.entries(currentShortcut.shortcutModifiers)
+        .every(([_, modifier]) => modifier.pressed === event[modifier.key])
+
+  }
+
   function addKeyboardShortcut(callback) {
     document.addEventListener("keydown", (event) => {
-      if (event.altKey && event.metaKey && event.shiftKey && event.code === "KeyL") {
+      if (isCurrentShortcutPressed(event)) {
         callback(el)
       }
     });

--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -10,6 +10,7 @@
 // @require      https://gist.github.com/raw/2625891/waitForKeyElements.js
 // @grant GM_addStyle
 // @updateURL    https://raw.githubusercontent.com/licarth/paste-notion-urls/main/tampermonkey-script.js
+// @grant        GM_registerMenuCommand
 // @downloadURL  https://raw.githubusercontent.com/licarth/paste-notion-urls/main/tampermonkey-script.js
 // ==/UserScript==
 
@@ -237,3 +238,48 @@ function copyLinkToPage(emoji, title, href, textDiv) {
 (function () {
   waitForKeyElements(".notion-topbar-share-menu", displayButton, false);
 })();
+
+
+function buildModalBackdrop() {
+  const backdrop = document.createElement('div');
+  backdrop.classList.add("backdrop");
+  return backdrop;
+}
+
+function buildModal() {
+  const modal = document.createElement('div');
+  modal.classList.add("modal");
+  return modal;
+}
+function buildModalButtons(tempShortcut, backdrop) {
+}
+
+function buildShortcutSetting(tempShortcut) {
+};
+
+function showSettingsModal() {
+  const tempShortcut = {
+    shortcutKey: currentShortcut.shortcutKey,
+    shortcutModifiers: currentShortcut.shortcutModifiers
+  }
+
+  // Build the modal elements
+  const backdrop = buildModalBackdrop();
+  const modal = buildModal();
+  const shortcutSetting = buildShortcutSetting(tempShortcut);
+  const { saveButton, cancelButton } = buildModalButtons(tempShortcut, backdrop);
+
+  // Assemble elements in DOM
+  document.body.appendChild(backdrop);
+  backdrop.appendChild(modal);
+
+  modal.appendChild(shortcutSetting);
+  modal.appendChild(saveButton);
+  modal.appendChild(cancelButton);
+
+  modal.focus();
+}
+
+
+// Add a menu command to open the setting
+GM_registerMenuCommand("Set copy shortcut", showSettingsModal);

--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -128,13 +128,23 @@ align-items: center;
   el.parentNode.insertBefore(linkDiv, el.parentNode.firstChild);
 
   if (peekPreview) {
+    addKeyboardShortcut(onButtonClickPeek);
     document
       .getElementById("copyUrlButtonPeek")
       .addEventListener("click", () => onButtonClickPeek(el), false);
   } else {
+    addKeyboardShortcut(onButtonClickMain);
     document
       .getElementById("copyUrlButtonMain")
       .addEventListener("click", () => onButtonClickMain(el), false);
+  }
+
+  function addKeyboardShortcut(callback) {
+    document.addEventListener("keydown", (event) => {
+      if (event.ctrlKey && event.shiftKey && event.code === "KeyC") {
+        callback(el)
+      }
+    });
   }
 
   function onButtonClickMain(element) {

--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -141,7 +141,7 @@ align-items: center;
 
   function addKeyboardShortcut(callback) {
     document.addEventListener("keydown", (event) => {
-      if (event.ctrlKey && event.shiftKey && event.code === "KeyC") {
+      if (event.altKey && event.metaKey && event.shiftKey && event.code === "KeyL") {
         callback(el)
       }
     });

--- a/tampermonkey-script.js
+++ b/tampermonkey-script.js
@@ -311,7 +311,7 @@ GM_addStyle(`
   text-align: center;
   font-weight: 700;
   line-height: 1;
-  padding: 5px 0 4px 5px;
+  padding: 5px 0;
   margin: 0 6px 20px 0;
   background-color: #b4b4b4;
   height: 40px;


### PR DESCRIPTION
This PR adds 
- a modal to set a custom shortcut via Tampermonkey menu.
- a default shortcut `⌘+⌥+⇧+L` to align with notion

<img width="393" alt="Screenshot 2023-05-07 at 17 34 49" src="https://user-images.githubusercontent.com/47712216/236692623-817535c2-121f-4d50-94df-dd84ee124a8a.png">
<img width="926" alt="Screenshot 2023-05-07 at 19 28 09" src="https://user-images.githubusercontent.com/47712216/236693062-3f11ad1e-75f0-488f-a453-2b75ac744464.png">
<img width="926" alt="Screenshot 2023-05-07 at 19 28 30" src="https://user-images.githubusercontent.com/47712216/236693063-71d6162a-e662-4e4b-9b3c-3977bc46c7e3.png">
